### PR TITLE
Bugfixing collate function

### DIFF
--- a/segmentation/utils/collate.py
+++ b/segmentation/utils/collate.py
@@ -5,7 +5,8 @@
 import torch
 import numpy as np
 import collections
-from torch._six import string_classes, int_classes
+from torch._six import string_classes
+int_classes = (bool, int)
 
 
 def collate_custom(batch):


### PR DESCRIPTION
`int_classes` was removed from `torch._six`. So I'm applying a fix (seen here: https://github.com/visionml/pytracking/issues/272#issuecomment-898898034).